### PR TITLE
Fix: 곡별 사운드 옵션을 반영하여 미디 파일을 생성하도록 수정

### DIFF
--- a/RhythmTokTok/Utils/MusicPlayer.swift
+++ b/RhythmTokTok/Utils/MusicPlayer.swift
@@ -56,6 +56,17 @@ class MusicPlayer: ObservableObject {
         }
     }
     
+    private func getSoundFont() -> String {
+        switch UserSettingData.shared.getSoundOption() {
+        case .melody:
+            return "Piano"
+        case .beat:
+            return "Drum Set JD Rockset 5"
+        default:
+            return "Piano"
+        }
+    }
+    
     // 오디오 파일 로드
     func loadAudioFile(url: URL) {
         do {
@@ -113,7 +124,7 @@ class MusicPlayer: ObservableObject {
         // AVMIDIPlayer 초기화
         do {
             
-            let bankURL = Bundle.main.url(forResource: soundFont, withExtension: "sf2")! // 사운드 폰트 파일 경로
+            let bankURL = Bundle.main.url(forResource: getSoundFont(), withExtension: "sf2")! // 사운드 폰트 파일 경로
             
             midiPlayer = try AVMIDIPlayer(contentsOf: midiURL, soundBankURL: bankURL)
             


### PR DESCRIPTION
## 📌 이슈 번호
- #144 
 
## 🧑‍💻 작업 내용
유저디폴트로 곡별 사운드 설정이 저장되도록 바뀌었는데, 기존의 미디 파일 재생 로직에서는 변경된 사운드 폰트가 반영되지 않는 문제가 있었습니다. 곡별로 사운드 설정이 가능하게 된 수정 사항을 반영하여 미디 파일을 재생하도록 바꾸었습니다.

