### PR TITLE
Watch 햅틱 테스트를 위한 옵션 기능, 뷰 구현

### DIFF
--- a/RhythmTokTok.xcodeproj/project.pbxproj
+++ b/RhythmTokTok.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		729220582CBE799D008C8FCF /* Countdown.json in Resources */ = {isa = PBXBuildFile; fileRef = 729220572CBE799D008C8FCF /* Countdown.json */; };
 		D34EEB622CC2A80F007BE568 /* PlayStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34EEB612CC2A80F007BE568 /* PlayStatus.swift */; };
 		D34EEB632CC2A8ED007BE568 /* PlayStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34EEB612CC2A80F007BE568 /* PlayStatus.swift */; };
+		D35FC8C72CDA3C0100923736 /* WatchHapticOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35FC8C62CDA3C0100923736 /* WatchHapticOptionView.swift */; };
 		D3693D6F2CD3C7EE00E37D2C /* WatchCountdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3693D6E2CD3C7EE00E37D2C /* WatchCountdownView.swift */; };
 		D36E430D2CB642630038994B /* WatchtoiOSConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36E430C2CB642630038994B /* WatchtoiOSConnectivityManager.swift */; };
 		D39BAA272CBA6536002AD1C0 /* SoundSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39BAA262CBA6536002AD1C0 /* SoundSetting.swift */; };
@@ -249,6 +250,7 @@
 		729220552CBE48DB008C8FCF /* change.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = change.json; sourceTree = "<group>"; };
 		729220572CBE799D008C8FCF /* Countdown.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Countdown.json; sourceTree = "<group>"; };
 		D34EEB612CC2A80F007BE568 /* PlayStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayStatus.swift; sourceTree = "<group>"; };
+		D35FC8C62CDA3C0100923736 /* WatchHapticOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchHapticOptionView.swift; sourceTree = "<group>"; };
 		D3693D6E2CD3C7EE00E37D2C /* WatchCountdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchCountdownView.swift; sourceTree = "<group>"; };
 		D36E430C2CB642630038994B /* WatchtoiOSConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchtoiOSConnectivityManager.swift; sourceTree = "<group>"; };
 		D39BAA262CBA6536002AD1C0 /* SoundSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSetting.swift; sourceTree = "<group>"; };
@@ -643,6 +645,7 @@
 			isa = PBXGroup;
 			children = (
 				02CFE1232CB1156C008454B8 /* WatchWaitingView.swift */,
+				D35FC8C62CDA3C0100923736 /* WatchHapticOptionView.swift */,
 				D3693D6E2CD3C7EE00E37D2C /* WatchCountdownView.swift */,
 				D3D6D1B62CBE568C00D22886 /* WatchPlayView.swift */,
 				D3D6D1B82CBE8B6300D22886 /* WatchScoreTitleView.swift */,
@@ -924,6 +927,7 @@
 				D36E430D2CB642630038994B /* WatchtoiOSConnectivityManager.swift in Sources */,
 				D3D6D1B92CBE8B6300D22886 /* WatchScoreTitleView.swift in Sources */,
 				02CFE1352CB7D91F008454B8 /* ErrorHandler.swift in Sources */,
+				D35FC8C72CDA3C0100923736 /* WatchHapticOptionView.swift in Sources */,
 				02CFE1242CB1156C008454B8 /* WatchWaitingView.swift in Sources */,
 				02CFE1222CB1156C008454B8 /* RhythmTokTokWatchApp.swift in Sources */,
 				D3D6D1B72CBE568C00D22886 /* WatchPlayView.swift in Sources */,

--- a/RhythmTokTokWatchApp/Manager/HapticScheduleManager.swift
+++ b/RhythmTokTokWatchApp/Manager/HapticScheduleManager.swift
@@ -12,12 +12,14 @@ import WatchKit
 
 class HapticScheduleManager: NSObject, WKExtendedRuntimeSessionDelegate, ObservableObject {
     @Published var isHapticActive: Bool = false
+    @Published var hapticType: WKHapticType = .start // 선택된 햅틱 타입
+    
     var cancellables = Set<AnyCancellable>()
 
     private var session: WKExtendedRuntimeSession?
     private var timers: [DispatchSourceTimer] = [] // 햅틱 타임스케쥴러 관리 배열
     private var currentBatchIndex = 0 // 현재 실행 중인 배치 인덱스
-    private var hapticType: WKHapticType = .start
+//    private var hapticType: WKHapticType = .start
     private var beatTimes: [Double] = []
     private var startTimeInterval: TimeInterval = 0
 
@@ -102,7 +104,7 @@ class HapticScheduleManager: NSObject, WKExtendedRuntimeSessionDelegate, Observa
         timer.schedule(deadline: .now(), repeating: interval, leeway: .milliseconds(50))
         timer.setEventHandler {
             DispatchQueue.main.async {
-                WKInterfaceDevice.current().play(.start) // 선택된 햅틱 타입 적용
+                WKInterfaceDevice.current().play(self.hapticType) // 선택된 햅틱 타입 적용
             }
         }
         timer.resume()
@@ -128,7 +130,7 @@ class HapticScheduleManager: NSObject, WKExtendedRuntimeSessionDelegate, Observa
             timer.schedule(deadline: .now() + beatTime, leeway: .milliseconds(1))
             timer.setEventHandler {
                 DispatchQueue.main.async {
-                    WKInterfaceDevice.current().play(.start)  // 햅틱 실행
+                    WKInterfaceDevice.current().play(self.hapticType)  // 선택된 햅틱 타입 적용
                 }
             }
             timer.resume()

--- a/RhythmTokTokWatchApp/View/WatchHapticOptionView.swift
+++ b/RhythmTokTokWatchApp/View/WatchHapticOptionView.swift
@@ -1,0 +1,87 @@
+//
+//  WatchHapticOptionView.swift
+//  RhythmTokTokWatchApp
+//
+//  Created by Byeol Kim on 11/5/24.
+//
+
+import SwiftUI
+import WatchKit
+
+//MARK: - 워치 햅틱 세기 테스트를 위한 테스트뷰
+struct WatchHapticOptionView: View {
+    @EnvironmentObject var connectivityManager: WatchtoiOSConnectivityManager
+    @State private var selectedHapticType: WKHapticType = .start
+    
+    // 선택 가능한 모든 햅틱 타입을 나열 (유효한 타입만 포함)
+    let hapticTypes: [WKHapticType] = [
+        .start,
+        .notification,
+        .directionUp,
+        .directionDown,
+        .success,
+        .stop,
+        .failure,
+        .retry,
+        .click
+    ]
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                Picker("Haptic Type", selection: $selectedHapticType) {
+                    ForEach(hapticTypes, id: \.self) { haptic in
+                        Text(hapticDisplayName(for: haptic))
+                            .tag(haptic)
+                    }
+                }
+                .pickerStyle(WheelPickerStyle())
+                .onChange(of: selectedHapticType) { newValue in
+                    connectivityManager.hapticManager.setHapticType(type: newValue)
+                    WKInterfaceDevice.current().play(newValue) // 선택 즉시 피드백 제공
+                }
+                .padding()
+                
+                Text("선택된 햅틱 타입: \(hapticDisplayName(for: selectedHapticType))")
+                    .foregroundColor(.white)
+                    .font(.headline)
+                    .padding()
+            }
+            .navigationTitle("Haptic Selection")
+            .background(Color.black.edgesIgnoringSafeArea(.all))
+        }
+    }
+    
+    // 햅틱 타입에 따른 표시 이름 반환
+    func hapticDisplayName(for type: WKHapticType) -> String {
+        switch type {
+        case .start:
+            return "Start"
+        case .stop:
+            return "Stop"
+        case .click:
+            return "Click"
+        case .directionUp:
+            return "Direction Up"
+        case .directionDown:
+            return "Direction Down"
+        case .success:
+            return "Success"
+        case .failure:
+            return "Failure"
+        case .retry:
+            return "Retry"
+        case .notification:
+            return "Notification"
+        @unknown default:
+            return "Unknown"
+        }
+    }
+}
+//
+// struct HapticSelectionView_Previews: PreviewProvider {
+//     static var previews: some View {
+//         HapticSelectionView()
+//             .environmentObject(WatchtoiOSConnectivityManager())
+//     }
+// }

--- a/RhythmTokTokWatchApp/View/WatchWaitingView.swift
+++ b/RhythmTokTokWatchApp/View/WatchWaitingView.swift
@@ -11,35 +11,48 @@ import SwiftUI
 
 struct WatchWaitingView: View {
     @EnvironmentObject var connectivityManager: WatchtoiOSConnectivityManager
-//    @StateObject var logger = Logger.shared
+    //    @StateObject var logger = Logger.shared
     
     var body: some View {
-        ZStack {
-            Image("BasicBackground")
-                .resizable()
-                .scaledToFill()
-                .edgesIgnoringSafeArea(.all)
-
-            // TODO: 테스트 코드임 삭제 필요
-//            VStack {
-//                Text("세션 활성화 횟수 : \(logger.activatedSession)")
-//                    .font(.system(size: 8))
-//                Text("예약 시간 : \(logger.watchScheduledTime)")
-//                    .font(.system(size: 8))
-//                Text("시작 시간 : \(logger.watchHapticTime)")
-//                    .font(.system(size: 8))
-//            }
-            // 여기 까지
-            
-            if connectivityManager.isSelectedScore {
-                WatchPlayView()
-            } else {
-                Text("아이폰에서\n연습하고 싶은 곡을\n선택해 주세요.")
-                    .multilineTextAlignment(.leading)
-                    .font(Font.custom("Pretendard-Bold", size: 20))
-                    .foregroundColor(.white)
-                    .padding()
+        TabView {
+            ZStack {
+                Image("BasicBackground")
+                    .resizable()
+                    .scaledToFill()
+                    .edgesIgnoringSafeArea(.all)
+                
+                // TODO: 테스트 코드임 삭제 필요
+                //            VStack {
+                //                Text("세션 활성화 횟수 : \(logger.activatedSession)")
+                //                    .font(.system(size: 8))
+                //                Text("예약 시간 : \(logger.watchScheduledTime)")
+                //                    .font(.system(size: 8))
+                //                Text("시작 시간 : \(logger.watchHapticTime)")
+                //                    .font(.system(size: 8))
+                //            }
+                // 여기 까지
+                
+                if connectivityManager.isSelectedScore {
+                    WatchPlayView()
+                } else {
+                    Text("아이폰에서\n연습하고 싶은 곡을\n선택해 주세요.")
+                        .multilineTextAlignment(.leading)
+                        .font(Font.custom("Pretendard-Bold", size: 20))
+                        .foregroundColor(.white)
+                        .padding()
+                }
             }
+            .tabItem {
+                Image(systemName: "music.note.list")
+                Text("Play")
+            }
+            
+            // 햅틱 선택 뷰
+            WatchHapticOptionView()
+                .tabItem {
+                    Image(systemName: "waveform.path.badge.plus")
+                    Text("Haptics")
+                }
         }
     }
 }


### PR DESCRIPTION
 <!-- 연관된 이슈 번호를 모두 작성해 주세요. ex, #23, #24 -->
## 📌 이슈 번호
- #169 

<!--  제목 : 작업 내용 간략하게 (ex. 메인화면 홈버튼 구현) -->
## 🧑‍💻 작업 내용
- 워치에서 햅틱 종류 선택시 종류에 따른 햅틱 재생 구현
- 햅틱 선택을 위한 뷰 구현

## 💬 참고 사항
- 워치 햅틱에는 총 9개의 종류가 있는데, 테스트 결과 현재 start가 가장 적절하다는 생각이 듭니다.. 
- 테스트 결과는 아래와 같고 pull 받아서 햅틱 적용 한번 해보시길 바랍니다~~ ͙ᐟ 
 ⭐️ start : 현재 진동
  notification : 2번 울림
  directionUp : 2번 울림
  directionDown : 2번 울림
  success  : 2번 울림
  stop : 2번 울림
  failure : 진동이 길어서 한음한음 표현이 안됨.
  retry  : 진동이 길어서 한음한음 표현이 안됨.
  click : 너무 약함

## 📱 시연 영상 / 스크린샷
<img src="https://github.com/user-attachments/assets/1e7481e5-0bc2-4bba-8d8b-de2ad24e8e23" width="300" />


<!-- 확인 사항
제목 : 작업 내용 간략하게 (ex. 메인화면 홈버튼 구현)

프로젝트 안의 이슈 연동시키기

라벨 붙이기 —>
