### PR TITLE
HandleNoteTie 로직 리팩토링

### DIFF
--- a/RhythmTokTok/Managers/MediaManager.swift
+++ b/RhythmTokTok/Managers/MediaManager.swift
@@ -159,7 +159,7 @@ class MediaManager {
         return score
     }
     
-    private func handleNoteTie(_ note: inout Note, _ tieStartNotes: inout [String: Note]) {
+    private func handleNoteTie(_ note: Note, _ tieStartNotes: inout [String: Note]) -> Note? {
         let noteKey = "\(note.staff)-\(note.pitch)-\(note.octave)-\(note.voice)" // Unique key
         if let tieType = note.tieType {
             if tieType == "start" {
@@ -176,11 +176,13 @@ class MediaManager {
                 // 그 노트를 사용하여 MIDI파일에 붙임
                 if tieStartNotes[noteKey] != nil {
                     tieStartNotes[noteKey]!.duration += note.duration
-                    note = tieStartNotes[noteKey]!
+                    let modifiedNote = tieStartNotes[noteKey]!
                     tieStartNotes.removeValue(forKey: noteKey)
+                    return modifiedNote
                 }
             }
         }
+        return nil
     }
     
     
@@ -198,8 +200,11 @@ class MediaManager {
             
             // 붙임줄 관련 처리 로직
             if let tieType = note.tieType {
-                handleNoteTie(&note, &tieStartNotes)
-                if tieType == "start" {
+                if let modifiedNote = handleNoteTie(note, &tieStartNotes) {
+                    // tieType이 end일 때 바꿔넣을 note가 return됨
+                    // note 바꿔넣기
+                    note = modifiedNote
+                } else {
                     continue
                 }
             }
@@ -445,8 +450,11 @@ class MediaManager {
             
             // 붙임줄 관련 처리 로직
             if let tieType = note.tieType {
-                handleNoteTie(&note, &tieStartNotes)
-                if tieType == "start" {
+                if let modifiedNote = handleNoteTie(note, &tieStartNotes) {
+                    // tieType이 end일 때 바꿔넣을 note가 return됨
+                    // note 바꿔넣기
+                    note = modifiedNote
+                } else {
                     continue
                 }
             }


### PR DESCRIPTION
## 📌 이슈 번호
- #195 

## 🧑‍💻 작업 내용
기존 createMIDIFile 내의 붙임줄 수정 로직에서는 원본 Score에 보관된 note의 duration을 수정하는 방식이었습니다. 이는 원본을 훼손하는 방법이므로, 대신에 붙임줄을 만났을 때 dictionary에 note의 copy를 저장하여 duration 관련 로직을 처리하고, 붙임줄이 끝났을 때 수정된 note를 return하여 기존 note를 대체하는 방식으로 수정하였습니다.