### PR TITLE
키보드에 붙어있는 액세서리 버튼 탭할 시 다음 뷰로 이동

### DIFF
--- a/RhythmTokTok/ViewControllers/TitleInputViewController.swift
+++ b/RhythmTokTok/ViewControllers/TitleInputViewController.swift
@@ -63,6 +63,7 @@ class TitleInputViewController: UIViewController, TitleInputViewDelegate, UIText
         // 키보드에 붙은 버튼이 터치되었을 때의 액션
         if buttonStatus == .active {
             titleInputView.textField.resignFirstResponder() // 키보드 dismiss
+            didTapCompleteButton(with: titleInputView.textField.text!)
         }
     }
 


### PR DESCRIPTION
## 📌 이슈 번호
- #243 

## 🧑‍💻 작업 내용
키보드에 붙어있는 액세서리 버튼 탭할 시 다음 뷰로 이동하도록 수정하였습니다.

## 📱 시연 영상 / 스크린샷
https://github.com/user-attachments/assets/bdb395aa-cb24-4713-8d2a-582bc359ef3c

