### PR TITLE
리스트뷰로 돌아갈 때 워치 선택화면으로 전환 로직 디버깅, 워치 버튼 요청 수신 로직 재구현

### DIFF
--- a/RhythmTokTok/Managers/IOStoWatchConnectivityManager.swift
+++ b/RhythmTokTok/Managers/IOStoWatchConnectivityManager.swift
@@ -168,6 +168,7 @@ class IOStoWatchConnectivityManager: NSObject, WCSessionDelegate, ObservableObje
         }
     }
     
+    // MARK: UserInfo 수신
     func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any]) {
         DispatchQueue.main.async {
             if let isActive = userInfo["SessionStatus"] as? Bool {
@@ -178,7 +179,26 @@ class IOStoWatchConnectivityManager: NSObject, WCSessionDelegate, ObservableObje
                     if self.watchAppStatus == .connected || self.watchAppStatus == .ready {
                         self.watchAppStatus = .backgroundInactive
                     }
-                }            }
+                }
+            }
+        }
+    }
+    
+    // MARK: Context 수신
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+        DispatchQueue.main.async {
+            if let playStatusString = applicationContext["playStatus"] as? String,
+               let receivedPlayStatus = PlayStatus(rawValue: playStatusString) {
+                self.receivedPlayStatus = receivedPlayStatus
+                print("워치로부터 수신한 재생 상태: \(receivedPlayStatus.rawValue)")
+                
+                // 상태 변경에 대한 알림을 전송
+                if receivedPlayStatus == .play {
+                    NotificationCenter.default.post(name: .watchPlayButtonTapped, object: nil)
+                } else if receivedPlayStatus == .pause {
+                    NotificationCenter.default.post(name: .watchPauseButtonTapped, object: nil)
+                }
+            }
         }
     }
 }

--- a/RhythmTokTok/ViewControllers/ScorePracticeViewController.swift
+++ b/RhythmTokTok/ViewControllers/ScorePracticeViewController.swift
@@ -84,7 +84,7 @@ class ScorePracticeViewController: UIViewController, UIGestureRecognizerDelegate
     
     override func viewWillDisappear(_ animated: Bool) {
         IOStoWatchConnectivityManager.shared.watchAppStatus = .ready
-        musicPlayer.stopMIDI()
+        resetScore()
         resetSwipeGesture()
         NotificationCenter.default.removeObserver(self)
         cancellables.removeAll()
@@ -347,17 +347,15 @@ class ScorePracticeViewController: UIViewController, UIGestureRecognizerDelegate
     // MARK: 네비게이션 버튼 액션
     @objc private func backButtonTapped() {
         // 뒤로 가기 동작
+        resetScore()
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+    func resetScore() {
         musicPlayer.stopMIDI()
         IOStoWatchConnectivityManager.shared.playStatus = .ready
         // 초기화 로직
-//        let emptyScore = Score()
         IOStoWatchConnectivityManager.shared.sendScoreSelection(scoreTitle: "", hapticSequence: [])
-//            .sendUpdateStatusWithHapticSequence(currentScore: emptyScore,
-//                                                hapticSequence: [],
-//                                                status: .ready, startTime: 0)
-        
-        
-        self.navigationController?.popViewController(animated: true)
     }
 
     func handlePlayStatusChange(_ status: PlayStatus) {

--- a/RhythmTokTokWatchApp/Manager/WatchtoiOSConnectivityManager.swift
+++ b/RhythmTokTokWatchApp/Manager/WatchtoiOSConnectivityManager.swift
@@ -117,6 +117,7 @@ class WatchtoiOSConnectivityManager: NSObject, ObservableObject, WCSessionDelega
             self.hapticManager.stopHaptic()
             self.selectedScoreTitle = scoreTitle
             self.hapticSequence = hapticSequence
+            self.isSelectedScore = !scoreTitle.isEmpty
         } else {
             ErrorHandler.handleError(error: "받은 햅틱이 없습니다")
         }


### PR DESCRIPTION
 <!-- 연관된 이슈 번호를 모두 작성해 주세요. ex, #23, #24 -->
## 📌 이슈 번호
- #315
<!--  제목 : 작업 내용 간략하게 (ex. 메인화면 홈버튼 구현) -->
## 🧑‍💻 작업 내용
+ 리스트뷰로 돌아갈 때 빈 타이틀 전송
+ 워치 context요청 수신 로직 재구현

## 💬 참고 사항

## 📱 시연 영상 / 스크린샷

<!-- 확인 사항
제목 : 작업 내용 간략하게 (ex. 메인화면 홈버튼 구현)

프로젝트 안의 이슈 연동시키기

라벨 붙이기 —>
